### PR TITLE
Early game balance tweaks, justice for Viper & Skymage

### DIFF
--- a/all.txt
+++ b/all.txt
@@ -227,11 +227,11 @@
         //-------------------------------------------------------------------------------------------------------------
         "AbilityValues"
         {
-            "percent_damage_per_burn"       "50"
-            "mana_per_hit"          "28 40 52 64"
+            "percent_damage_per_burn"       "50 55 60 65 70 75 80 85 90 95" // Wouldn't be that much because that still gets reduced by armor
+            "mana_per_hit"          "28 40 52 64 76 88 100 112 124 136" // This scaling was needed
             "mana_per_hit_pct"      
             {
-                "value"     "1 1.8 2.6 3.4 3.8 4.2 4.8 5.1 5.3 5.5"
+                "value"     "3.4 3.8 4.2 4.6 5.0 5.4 5.8 6.2 6.6 7" // Makes more sense now
                 "special_bonus_unique_antimage_7"   "+0.6"
             }
             "illusion_percentage"       "50"
@@ -276,7 +276,7 @@
         {
                 "AbilityCooldown"               
                 {
-                    "value"         "15 12 9 6 4 3 2 2 2 2"
+                    "value"         "11 10 9 8 7 6 5 4 3 2" //Useless anyway
                     "special_bonus_unique_antimage" "-1"
                 }
                 "AbilityCastRange"          
@@ -306,7 +306,7 @@
             "01"
             {
                 "var_type"                      "FIELD_INTEGER"
-                "spell_shield_resistance"       "20 30 40 50"
+                "spell_shield_resistance"       "20 30 40 50" // It doesn't work, please remove from abilites pool
             }
             "02"
             {
@@ -352,7 +352,7 @@
         {
             "magic_resistance"          
             {
-                "value"         "5 10 15 20 25 30 35 40 45 50"
+                "value"         "23 26 29 32 35 38 41 44 47 50" // More friendly scaling
                 "special_bonus_unique_antimage_4"   "+15"
             }
             "duration"                  "1.2"
@@ -428,8 +428,8 @@
             }
             "mana_void_damage_per_mana"     
             {
-                "value"             "0.8 0.95 1.1 1.2 1.3 1.4 1.6 1.8 1.9 2.0"
-                "special_bonus_unique_antimage_6"   "+0.1"
+                "value"             "0.8 0.95 1.1 1.25 1.4 1.55 1.7 1.85 2 2.15" // Smoother scaling
+                "special_bonus_unique_antimage_6"   "+0.2" // More useful now
             }           
             "mana_void_ministun"            
             {
@@ -14510,7 +14510,7 @@
                 "duration"                      "4"
                 "damage"                    
                 {
-                    "value"                 "6 12 18 24 30 36 42 48 54 60"
+                    "value"                 "12 18 24 30 36 42 48 54 60 66" //Better at level 1
                     "special_bonus_unique_viper_7"  "+25%"
                 }   
                 "movement_speed"            
@@ -14563,7 +14563,7 @@
 
         // Time     
         //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "14.0 13 12 11 10 9 8 7 6 5"
+        "AbilityCooldown"               "12" // There's a -11s cd talent
         
         // Cost
         //-------------------------------------------------------------------------------------------------------------
@@ -14583,7 +14583,7 @@
             "02"
             {
                 "var_type"              "FIELD_INTEGER"
-                "max_damage"            "50 62 74 86 98 110 122 134 146 158"
+                "max_damage"            "50 75 100 125 150 175 200 225 250 275" //Scaling from Dota makes a lot more sense here
                 "LinkedSpecialBonus"    "special_bonus_unique_viper_3"
 
             }
@@ -14642,7 +14642,7 @@
             }
             "damage"
             {
-                "value"                 "8 24 40 56 72 88 104 120 136 152"
+                "value"                 "24 40 56 72 88 104 120 136 152 168" // More useful at lvl 1
                 "special_bonus_unique_viper_1"  "+13"
             }
             "max_range_tooltip"                 "1400"
@@ -14679,7 +14679,7 @@
         "AbilityUnitDamageType"         "DAMAGE_TYPE_MAGICAL"   
         "FightRecapLevel"               "2"
         "AbilitySound"                  "hero_viper.viperStrike"
-        "MaxLevel" "4"
+        "MaxLevel" "10"
         "HasScepterUpgrade"         "1"
 
         // Casting
@@ -14696,14 +14696,14 @@
 
             "damage"
             {
-                "value"             "80 240 400 560"
-                "special_bonus_unique_viper_2"  "+80"
+                "value"             "240 400 560 720 860 1020 1180 1340 1400 1560" // lvl 1 damage is too litle for an ultimate ability
+                "special_bonus_unique_viper_2"  "+160" // Talent buff
             }
             "bonus_movement_speed"  "-40 -60 -80 -100"
             "bonus_attack_speed"    "-40 -60 -80 -100"
             "AbilityCooldown"
             {
-                "value"             "50 40 30 20"
+                "value"             "30 25 20 15" // 50 sec cd is a joke
                 "special_bonus_unique_viper_8"      "-50%"
             }
             "AbilityManaCost"
@@ -34061,6 +34061,7 @@
         "FightRecapLevel"               "1"
         "AbilitySound"                  "Hero_SkywrathMage.ArcaneBolt.Cast"
         "HasScepterUpgrade"         "1"
+        "MaxLevel" "10"
         
         // Casting
         //-------------------------------------------------------------------------------------------------------------
@@ -34069,7 +34070,7 @@
         
         // Time     
         //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "5.0 4.0 3.0 2.0"
+        "AbilityCooldown"               "4.0 3.0 2.0 1.0" // Justice for the Skymage
 
         // Cost
         //-------------------------------------------------------------------------------------------------------------
@@ -34092,7 +34093,7 @@
             "03"
             {
                 "var_type"              "FIELD_FLOAT"
-                "bolt_damage"           "75 95 115 135"
+                "bolt_damage"           "75 95 115 135 155 175 195 215 235 255"
             }
             "04"
             {
@@ -34130,6 +34131,7 @@
         "FightRecapLevel"               "1"
         "AbilitySound"                  "Hero_SkywrathMage.ConcussiveShot.Cast"
         "HasScepterUpgrade"         "1"
+        "MaxLevel" "10"
 
         // Casting
         //-------------------------------------------------------------------------------------------------------------
@@ -34138,7 +34140,7 @@
         
         // Time     
         //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "15 14 13 12"
+        "AbilityCooldown"               "7 6 5 4" // Justice for the Skymage
 
 
         // Cost
@@ -34168,7 +34170,7 @@
             "04"
             {
                 "var_type"          "FIELD_INTEGER"
-                "damage"            "120 180 240 300"
+                "damage"            "120 180 240 300 360 420 480 540 600 660"
             }
             "05"
             {
@@ -34199,7 +34201,7 @@
             "10"
             {
                 "var_type"              "FIELD_INTEGER"
-                "creep_damage_pct"      "75"
+                "creep_damage_pct"      "100" // Seems reasonable
             }
         }
         "AbilityCastAnimation"      "ACT_DOTA_CAST_ABILITY_2"
@@ -34274,6 +34276,7 @@
         "AbilityType"                   "DOTA_ABILITY_TYPE_ULTIMATE"
         "SpellImmunityType"             "SPELL_IMMUNITY_ENEMIES_NO"
         "FightRecapLevel"               "2"
+        "MaxLevel" "10"
 
         "HasScepterUpgrade"         "1"
         "HasShardUpgrade"           "1"
@@ -34286,7 +34289,7 @@
         
         // Time     
         //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "60.0 40.0 20.0"
+        "AbilityCooldown"               "20.0 15.0 10.0" // Justice for the Skymage
 
         // Cost
         //-------------------------------------------------------------------------------------------------------------
@@ -34304,12 +34307,12 @@
             "02"
             {
                 "var_type"              "FIELD_FLOAT"
-                "duration"              "2.2"
+                "duration"              "3.0" // Some justice
             }
             "03"
             {
                 "var_type"              "FIELD_INTEGER"
-                "damage"                "800 1200 1600"
+                "damage"                "1200 1800 2400 3000 3600 4200 4800 5400 6000 6600" // Some justice
                 "LinkedSpecialBonus"    "special_bonus_unique_skywrath_5"
             }
             "04"

--- a/npc_abilities_custom.txt
+++ b/npc_abilities_custom.txt
@@ -237,10 +237,10 @@
         //-------------------------------------------------------------------------------------------------------------
         "AbilityValues"
         {
-            "damage" "6 20 34 48 62 76 90 104 118 132"
+            "damage" "20 34 48 62 76 90 104 118 132 146" // More useful at lvl 1
             "agi_to_damage"
             {
-                "value" "7 12 17 22 27 32 37 42 47 52"
+                "value" "50" // should make more sense
                 "CalculateSpellDamageTooltip"   "0"
             }
             "move_slow" "-3"
@@ -377,12 +377,12 @@
         "02"
         {
           "var_type"          "FIELD_INTEGER"
-          "damage"          "90 200 310 420 530 640 750 860 970 1080"
+          "damage"          "40 80 120 160 200 240 280 320 360 400" // This damage was huge (1200 per cast at lvl 2)
         }
         "03"
         {
           "var_type"          "FIELD_INTEGER"
-          "resistance"          "-3 -6 -9 -12 -15 -18 -21 -24 -27 -30"
+          "resistance"          "-12 -14 -16 -18 -20 -22 -24 -26 -28 -30" // Decreased level progression (3 - 30 -> 12 - 30)
           "CalculateSpellDamageTooltip"   "0"
         }
         "04"
@@ -514,7 +514,7 @@
             "01"
             {
                 "var_type"              "FIELD_FLOAT"
-                "attack_to_magic"  "4 8 10 12 14 16 18 20 22 24"
+                "attack_to_magic"  "4 8 10 12 14 16 18 20 22 24" // I suggest adding "no spell amplification" flag to the damage table
             }
             "02"
             {
@@ -961,12 +961,12 @@
             "03"
             {
                 "var_type"              "FIELD_FLOAT"
-                "bonus_armor_pct"              "3 6 9 12 15 18 21 24 27 30"
+                "bonus_armor_pct"              "30" // Percentage-based armor is totally worthless at low levels so flat value is better than level-scaling
             }
             "04"
             {
                 "var_type"              "FIELD_FLOAT"
-                "crit_chance"              "25"
+                "crit_chance"              "21 22 23 24 25 26 27 28 29 30" //Better scaling for mid and late-game
             }
             "05"
             {
@@ -2758,7 +2758,7 @@
         //-------------------------------------------------------------------------------------------------------------
         "AbilityValues"
         {
-            "attack_to_mana_leech_pct" "1.0 1.75 2.5 3.25 4.0 4.75 5.5 6.25 7.0 7.75"
+            "attack_to_mana_leech_pct" "3.5 4.0 4.5 5.0 5.5 6.0 6.5 7.0 7.5 8.0" // Making it useful at lower levels
         }
     }
 
@@ -2777,7 +2777,7 @@
         "AbilityValues"
         {
             "bonus_damage" "90 330 570 810 1050 1290 1530 1770 2010 2250"
-            "bonus_damage_agility" "4 10 16 22 28 34 40 46 52 58"
+            "bonus_damage_agility" "50" // Flat value seems more reasonable here
             "attack_speed_loss_pct" "-6 -8 -10 -12 -14 -16 -18 -20 -22 -24"
             "move_speed_loss_pct" "-4 -7 -10 -13 -16 -19 -22 -25 -28 -31"
         }
@@ -2850,7 +2850,7 @@
 
         // Time     
         //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "11 10 9 8 7 8 6 5 4 3"
+        "AbilityCooldown"               "7.5 7 6.5 6 5.5 5 4.5 4 3.5 3" // 11 sec is a huge cd for a skill like this
 
         // Special
         //-------------------------------------------------------------------------------------------------------------
@@ -2924,12 +2924,12 @@
             "05"
             {
                 "var_type"              "FIELD_INTEGER"
-                "attack_factor"         "-45 -40 -35 -30 -25 -20 -15 -10 -5 -0"
+                "attack_factor"         "-45 -35 -25 -15 -5 5 15 25 35 45" // That's useless anyway
             }
             "06"
             {
                 "var_type"              "FIELD_INTEGER"
-                "attack_factor_tooltip" "55 60 65 70 75 80 85 90 95 100"
+                "attack_factor_tooltip" "55 65 75 85 95 105 115 125 135 145"
             }
             "07"
             {
@@ -2958,7 +2958,7 @@
 
         // Time     
         //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "14 13 12 11 10 9 8 7 8 6"
+        "AbilityCooldown"               "14 13 12 11 10 9 8 7 6 5" // 8 7 8 was weird
 
         // Cost
         //-------------------------------------------------------------------------------------------------------------
@@ -3784,7 +3784,7 @@
             "03"
             {
                 "var_type"              "FIELD_INTEGER"
-                "pass_damage"           "100 140 180 220"
+                "pass_damage"           "110 155 200 245" // That's Dota values (I think we shouldn't have lower than those)
             }
             "04"
             {
@@ -3915,7 +3915,7 @@
             "03"
             {
                 "var_type"              "FIELD_INTEGER"
-                "pass_damage"           "100 140 180 220"
+                "pass_damage"           "110 155 200 245" // Same as the first one
             }
             "04"
             {
@@ -4023,7 +4023,7 @@
       "03"
       {
         "var_type"              "FIELD_INTEGER"
-        "stack_limit"           "4 8 12 16 20 24 28 32 36 40"
+        "stack_limit"           "12 14 16 18 20 22 24 26 28 30" // More useful at low levels, less stacks at the max level
       }
       "04"
       {
@@ -4039,7 +4039,7 @@
       "06"
       {
         "var_type"              "FIELD_FLOAT"
-        "base_armor_pct"          "0.25"
+        "base_armor_pct"          "0.3" // Due to stack count decrement
         "RequiresScepter" "1"
       }
     }
@@ -4344,7 +4344,7 @@
               "value" "56 72 88 104 120 136 152 168 184 200"
               "CalculateSpellDamageTooltip"                     "1"
             }
-            "duration"          "1.0 1.5 2.0 2.5 3.0 3.5 4.0 4.5 5.0 5.5"
+            "duration"          "2.8 3.1 3.4 3.7 4 4.3 4.6 4.9 5.2 5.5" //First three levels were useless
             "burn_interval"         "0.10"
             "linger_duration"           "0.2"
             "dragon_form_cast_range"    "1400"
@@ -4666,7 +4666,7 @@
 
         // Time     
         //-------------------------------------------------------------------------------------------------------------
-        "AbilityCooldown"               "28 26 24 22 20 18 16 14 12 10"
+        "AbilityCooldown"               "28 26 24 22 20 18 16 14 12 10" // I think 20+ is too much
 
         // Cost
         //-------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
A few tweaks to make early game better for some heroes
Little Anti-Mage buff
Viper buff
Skywrath Mage buff
OD Astral Eclipse nerf (to make its damage comparable to other heroes)
I've added some comments to all changes in .txt
I don't insist on any of this but it would've been cool

**Anti-Mage:**
**Mana Break:**
Mana Burned per Hit: 28/40/52/64 -> 28/40/52/64/76/88/100/112/124/136
Burned Mana as Damage: 50% -> 50/55/60/65/70/75/80/85/90/95%
Max Mana Burned per Hit: 1/1.8/2.6/3.4/3.8/4.2/4.8/5.1/5.3/5.5 -> 3.4/3.8/4.2/4.6/5.0/5.4/5.8/6.2/6.6/7
**Blink:**
Cooldown: 15/12/9/6/4/3/2/2/2/2 -> 11/10/9/8/7/6/5/4/3/2
**Counterspell:**
Magic Resistance Bonus: 5/10/15/20/25/30/35/40/45/50% -> 23/26/29/32/35/38/41/44/47/50%
**Mana Void:**
Damage per Missing Mana: 0.8/0.95/1.1/1.2/1.3/1.4/1.6/1.8/1.9/2.0 -> 0.8/0.95/1.1/1.25/1.4/1.55/1.7/1.85/2.0/2.15

**Drow Ranger:**
**Frost Arrows:**
Damage: 6/20/34/48/62/76/90/104/118/132 -> 20/34/48/62/76/90/104/118/132/146
Damage from Agility: 7/12/17/22/27/32/37/42/47/52% -> 50%

**Legion Commander:**
**War Zone:** 
Bonus Armor: 3%/6%/9%/12%/15%/18%/21%/24%/27%/30% -> 30%
Crit Chance: 25% -> 21/22/23/24/25/26/27/28/29/30%
**Outworld Destroyer:**
**Astral Eclipse:** 
Damage per Pulse: 90/200/310/420/530/640/750/860/970/1080 -> 40/80/120/160/200/240/280/320/360/400
Magic Resistance Reduction: 3/6/9/12/15/18/21/24/27/30% -> 12/14/16/18/20/22/24/26/28/30%

**Lion:** 
**Hellfire:**
Duration: 1/1.5/2/2.5/3/3.5/4/4.5/5/5.5 -> 2.8/3.1/3.4/3.7/4/4.3/4.6/4.9/5.2/5.5

**Medusa**:
**Mana Leech:**
Damage to Mana: 1.0/1.75/2.5/3.25/4.0/4.75/5.5/6.25/7.0/7.75% -> 3.5/4/4.5/5/5.5/6/6.5/7/7.5/8%
**Heavy Arrows:**
Damage from Agility: 4/10/16/22/28/34/40/46/52/58% -> 50%

**Phantom Assassin:** 
**Phantom Daggers:**
Instant Attack Damage: 55/60/65/70/75/80/85/90/95/100% -> 55/65/75/85/95/105/115/125/135/145%
**Swift Strike:**
Cooldown: 11/10/9/8/7/6/5/4/3 -> 7.5/7/6.5/6/5.5/5/4.5/4/3.5/3

**Skywrath Mage:**
**Arcane Bolt:**
Max Level: 4 -> 10
Base Damage: 75/95/115/135 -> 75/95/115/135/155/175/195/215/235/255
Cooldown: 5/4/3/2 -> 4/3/2/1
**Concussive Shot:**
Max Level: 4 -> 10
Damage: 120/180/240/300 -> 120/180/240/300/360/420/480/540/600/660
Creep Damage Percentage: 75% -> 100%
Cooldown: 15/14/13/12 -> 7/6/5/4
**Mystic Flare:**
Max Level: 3 -> 10
Total Damage: 800/1200/1600 -> 1200/1800/2400/3000/3600/4200/4800/5400/6000/6600
Flare Duration: 2.2 -> 3.0
Cooldown: 60/40/20 -> 20/15/10

**Timbersaw:**
**Reactive Armor:**
Max Stacks: 4/8/12/16/20/24/28/32/36/40 -> 12/14/16/18/20/22/24/26/28/30
Scepter Base Armor per Stack: 0.25% -> 0.3%
**Chakram:**
Pass Damage: 100/140/180/220 -> 110/155/200/245

**Viper:**
**Poison Attack:**
Damage per Second per Stack: 6/12/18/24/30/36/42/48/54/60 -> 12/18/24/30/36/42/48/54/60/66
**Nethertoxin:** 
Cooldown: 14/13/12/11/10/9/8/7/6/5 -> 12
Max Damage per Second: 50/62/74/86/98/110/122/134/146/158 -> 50/75/100/125/150/175/200/225/250/275
**Corrosive Skin:**
Damage per Second: 8/24/40/56/72/88/104/120/136/152 -> 24/40/56/72/88/104/120/136/152/168
**Viper Strike:**
Max Level: 4 -> 10
Damage per Second: 80/240/400/560 -> 240/400/560/720/860/1020/1180/1340/1400/1560
Cooldown: 50/40/30/20 -> 30/25/20/15